### PR TITLE
Migrate tests to Swift 6.2 exit tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: export RTSAN_OPTIONS="abort_on_error=false:halt_on_error=false"; swift test -v
+      run: swift test -v
   macos:
     runs-on: macos-26
     name: macOS
@@ -39,7 +39,6 @@ jobs:
     - name: Run tests
       run: |
         XCODE_DEV=$(xcode-select -p)
-        export RTSAN_OPTIONS="abort_on_error=false:halt_on_error=false"
         export DYLD_INSERT_LIBRARIES="/Users/runner/work/RTSanStandaloneSwift/RTSanStandaloneSwift/.build/arm64-apple-macosx/debug/libclang_rt.rtsan_osx_dynamic.dylib"
         export DYLD_FRAMEWORK_PATH="$XCODE_DEV/Platforms/MacOSX.platform/Developer/Library/Frameworks"
         "$XCODE_DEV/Toolchains/XcodeDefault.xctoolchain/usr/libexec/swift/pm/swiftpm-testing-helper" \

--- a/.swiftpm/xcode/xcshareddata/xcschemes/RTSanStandaloneSwift-Package.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/RTSanStandaloneSwift-Package.xcscheme
@@ -91,11 +91,6 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "RTSAN_OPTIONS"
-            value = "abort_on_error=false:halt_on_error=false"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "DYLD_INSERT_LIBRARIES"
             value = "/Users/josipcavar/Library/Developer/Xcode/DerivedData/rtsan-standalone-swift-dizgcjljjwdwckgznqnimwkurhwl/Build/Products/Debug/libclang_rt.rtsan_osx_dynamic.dylib"
             isEnabled = "YES">

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,10 +2,13 @@
 
 ## Tests
 
-When running tests, test runner needs to link sanitizer library. Since this executable is out of our control, we need to use `DYLD_INSERT_LIBRARIES` to force test runner to load sanitizer library.
-The issue is foundamentaly very similar to DAW -> Plugin interaction explained [here](https://forum.juce.com/t/using-realtimesanitizer-inside-daws/64557).
+Runtime tests use Swift 6.2 exit tests (`#expect(processExitsWith:)`). Each violation test runs in an isolated child process where RTSan can abort normally — tests expecting a violation use `.failure` and tests expecting no violation use `.success`.
 
-This environment variable is already set up in scheme settings in Xcode, but you might need to change to path on your machine for tests to work.
+### macOS
+
+On macOS, the test runner needs to link the sanitizer library. Since this executable is out of our control, we use `DYLD_INSERT_LIBRARIES` to force the test runner to load the sanitizer library. The issue is fundamentally very similar to DAW -> Plugin interaction explained [here](https://forum.juce.com/t/using-realtimesanitizer-inside-daws/64557).
+
+This environment variable is already set up in scheme settings in Xcode, but you might need to change the path on your machine for tests to work.
 
 E.g. when you run the test, you will get the following error:
 
@@ -15,20 +18,11 @@ DYLD_INSERT_LIBRARIES=/Users/josipcavar/Library/Developer/Xcode/DerivedData/RTSa
 "interceptors not installed" && 0
 ```
 
-Open Scheme settings and change `DYLD_INSERT_LIBRARIES` to environment variable to path in the log.
+Open Scheme settings and change `DYLD_INSERT_LIBRARIES` environment variable to the path in the log.
 
-Additionally, for tests to work, we need the following `RTSAN_OPTIONS`:
-- `abort_on_error=false`
-- `halt_on_error=false`
+### Linux
 
-These are both enabled in `RTSanStandaloneSwift-Package` scheme.
-
-Tests currently work by intercepting stderr output and making decisions based on that. This is not ideal, but seems like the only way to avoid test crash:
-
-- `abort_on_error` has to be false, otherwise the test will fail as the process will abort
-- `halt_on_error` has to be false, otherwise the test will fail as it will finish with a non-zero exit code
-- if the two above are false, death callback is not invoked
-- if `halt_on_error` is true, death callback is invoked but test will fail (due to non-zero) exit code
+On Linux, no special environment variables are needed — just run `swift test -v`.
 
 ## Build process
 

--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,7 @@ let package = Package(
                 "RealtimeSanitizerMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
             ],
-            swiftSettings: [.enableExperimentalFeature("Extern")]
+            swiftSettings: []
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -62,8 +62,7 @@ let package = Package(
                 "RealtimeSanitizerCore",
                 "RealtimeSanitizerMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
-            ],
-            swiftSettings: []
+            ]
         )
     ]
 )

--- a/Tests/RealtimeSanitizerTests/RealtimeSanitizerTests.swift
+++ b/Tests/RealtimeSanitizerTests/RealtimeSanitizerTests.swift
@@ -1,5 +1,4 @@
 import SwiftSyntax
-import Foundation
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 import RealtimeSanitizer
@@ -9,9 +8,6 @@ import Testing
 import Synchronization
 #if canImport(os)
 import os
-#endif
-#if canImport(SwiftGlibc)
-@preconcurrency import SwiftGlibc
 #endif
 import SwiftSyntaxMacrosGenericTestSupport
 
@@ -109,27 +105,25 @@ final class RealtimeSanitizerTests {
     }
 
     @Test
-    func testBlockingFunctionMarkedNonBlockingRaisesViolation() async throws {
-        @NonBlocking
-        func callBlocking() { print("asdf") }
-
-        await confirmation { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    func testBlockingFunctionMarkedNonBlockingRaisesViolation() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @NonBlocking
+            func callBlocking() { print("asdf") }
             callBlocking()
         }
     }
 
     @Test
     @available(iOS 18, macOS 15, *)
-    func testDetectsMutexLock() async throws {
-        @NonBlocking
-        func callBlocking() {
-            let mutex = Mutex(3)
-            mutex.withLock { $0 + 1 }
-        }
-
-        await confirmation { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    func testDetectsMutexLock() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @NonBlocking
+            func callBlocking() {
+                let mutex = Mutex(3)
+                mutex.withLock { $0 + 1 }
+            }
             callBlocking()
         }
     }
@@ -137,75 +131,60 @@ final class RealtimeSanitizerTests {
     #if canImport(os)
     @Test
     @available(iOS 16, *)
-    func testDetectsOSAllocatedUnfairLock() async throws {
-        @NonBlocking
-        func callBlocking() {
-            let lock = OSAllocatedUnfairLock(initialState: 3)
-            lock.withLock { $0 + 1 }
-        }
-
-        await confirmation { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    func testDetectsOSAllocatedUnfairLock() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @NonBlocking
+            func callBlocking() {
+                let lock = OSAllocatedUnfairLock(initialState: 3)
+                lock.withLock { $0 + 1 }
+            }
             callBlocking()
         }
     }
     #endif
+
     @Test
-    func testNonBlockingFunctionMarkedNonBlockingDoesntRaiseViolation() async throws {
+    func testNonBlockingFunctionMarkedNonBlockingDoesntRaiseViolation() {
         @NonBlocking
         func callNonBlocking() { 1 + 1 }
-
-        await confirmation(expectedCount: 0) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
-            callNonBlocking()
-        }
+        callNonBlocking()
     }
 
     @Test
-    func testNotifyBlockingCallRaiseViolation() async throws {
-
-        @NonBlocking
-        func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation() { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    func testNotifyBlockingCallRaiseViolation() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @NonBlocking
+            func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
             userBlocking()
         }
     }
 
     @Test
-    func testNotifyBlockingCallMacroRaiseViolation() async throws {
+    func testNotifyBlockingCallMacroRaiseViolation() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @Blocking
+            func userBlocking() { }
 
-        @Blocking
-        func userBlocking() { }
-
-        @NonBlocking
-        func callNonBlocking() { userBlocking() }
-
-        await confirmation() { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+            @NonBlocking
+            func callNonBlocking() { userBlocking() }
             callNonBlocking()
         }
     }
 
     @Test
-    func testBlockingCallDoesntRaiseViolationIfNotAnnotated() async throws {
-
+    func testBlockingCallDoesntRaiseViolationIfNotAnnotated() {
         func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation(expectedCount: 0) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
-            userBlocking()
-        }
+        userBlocking()
     }
 
     @Test
-    func testBlockingCallRaiseViolationWhenExplicitlyEntered() async throws {
-
-        func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation() { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    func testBlockingCallRaiseViolationWhenExplicitlyEntered() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
             RealtimeSanitizer.realtimeEnter()
             userBlocking()
             RealtimeSanitizer.realtimeExit()
@@ -213,82 +192,38 @@ final class RealtimeSanitizerTests {
     }
 
     @Test
-    func testBlockingCallDoesntRaiseViolationWhenExplicitlyEnteredButDisabled() async throws {
-
+    func testBlockingCallDoesntRaiseViolationWhenExplicitlyEnteredButDisabled() {
         func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation(expectedCount: 0) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
-            RealtimeSanitizer.disable()
-            RealtimeSanitizer.realtimeEnter()
-            userBlocking()
-            RealtimeSanitizer.realtimeExit()
-            RealtimeSanitizer.enable()
-        }
+        RealtimeSanitizer.disable()
+        RealtimeSanitizer.realtimeEnter()
+        userBlocking()
+        RealtimeSanitizer.realtimeExit()
+        RealtimeSanitizer.enable()
     }
 
     @Test
-    func testBlockingCallDoesntRaiseViolationWhenCompilationConditionNotActive() async throws {
-
+    func testBlockingCallDoesntRaiseViolationWhenCompilationConditionNotActive() {
         @NonBlocking(in: "CUSTOM")
         func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
+        userBlocking()
+    }
 
-        await confirmation(expectedCount: 0) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
+    @Test
+    func testBlockingCallRaisesViolationWhenInExplicitDEBUG() async {
+        await #expect(processExitsWith: .failure) {
+            RealtimeSanitizer.ensureInitialized()
+            @NonBlocking(in: "DEBUG")
+            func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
             userBlocking()
         }
     }
 
     @Test
-    func testBlockingCallRaisesViolationWhenInExplicitDEBUG() async throws {
-
-        @NonBlocking(in: "DEBUG")
-        func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation(expectedCount: 1) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
-            userBlocking()
-        }
-    }
-
-    @Test
-    func testBlockingCallDoesntRaiseViolationWhenInScopedDisabler() async throws {
-
+    func testBlockingCallDoesntRaiseViolationWhenInScopedDisabler() {
         @NonBlocking
         func userBlocking() { RealtimeSanitizer.notifyBlockingCall(functionName: "userBlocking") }
-
-        await confirmation(expectedCount: 0) { confirmation in
-            listenForUnsafeCall { confirmation.confirm() }
-            RealtimeSanitizer.withDisabled {
-                userBlocking()
-            }
+        RealtimeSanitizer.withDisabled {
+            userBlocking()
         }
     }
-}
-
-// extern "C" void __sanitizer_set_death_callback(void (*callback)(void));
-@_extern(c, "__sanitizer_set_death_callback")
-func setDeathCallback(_ callback: @convention(c) () -> Void) -> Void
-
-func listenForUnsafeCall(onDetect: @Sendable @escaping () -> Void) {
-    let outPipe = Pipe()
-    let savedStderr = dup(STDERR_FILENO)
-    outPipe.fileHandleForReading.readabilityHandler = { fileHandle in
-        let data = fileHandle.availableData
-        if data.isEmpty {
-            fileHandle.readabilityHandler = nil
-        }
-        if let str = String(data: data,  encoding: .utf8) {
-            if str.contains("unsafe-library-call") || str.contains("blocking-call") {
-                fileHandle.readabilityHandler = nil
-                dup2(savedStderr, STDERR_FILENO)
-                try! outPipe.fileHandleForWriting.close()
-                close(savedStderr)
-                print(str)
-                onDetect()
-            }
-        }
-    }
-    setvbuf(stderr, nil, _IONBF, 0)
-    dup2(outPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
 }


### PR DESCRIPTION
## Summary

- Replace the stderr-hijacking + `@_extern(c)` death callback approach with Swift 6.2 `#expect(processExitsWith:)` exit tests
- Violation tests now run in isolated subprocesses where RTSan can abort normally (`.failure`), no-violation tests run directly
- Remove `RTSAN_OPTIONS=abort_on_error=false:halt_on_error=false` from CI and Xcode scheme — no longer needed
- Remove `Extern` experimental feature flag from `Package.swift` and drop `Foundation`/`SwiftGlibc` imports

## Test plan

- [x] CI passes on Linux (`swift test -v`)
- [x] CI passes on macOS (with `DYLD_INSERT_LIBRARIES` set)
- [x] All exit tests correctly detect violations (`.failure`) and non-violations (`.success`)